### PR TITLE
fix test: str(qualification) returns the SAQA qualification name

### DIFF
--- a/django_project/ford3/tests/models/test_qualification.py
+++ b/django_project/ford3/tests/models/test_qualification.py
@@ -6,4 +6,4 @@ class TestQualification(TestCase):
 
     def test_qualification_name(self):
         new_qualification = ModelFactories.get_qualification_test_object()
-        self.assertEqual(new_qualification.__str__(), 'Object Test Name')
+        self.assertEqual(str(new_qualification), 'SAQAQualification name')


### PR DESCRIPTION
Fix #166 