### PR TITLE
Run selenium-up after collectstatic

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,8 @@ jobs:
       script:
         - pushd deployment
         - echo "Preparing Docker Stack"
-        - make build up wait-for-db generate-django-secret migrate collectstatic selenium-up
+        - make build up wait-for-db generate-django-secret migrate collectstatic
+        - make selenium-up
         - make status
         - echo "Docker stack ready"
         - echo "Preparing unittests"


### PR DESCRIPTION
Fix #299 

The build failed because `collectstatic` because of #300 then `selenium-up` would not be executed.
Without selenium up, some tests cannot run.