### PR TITLE
Updated sidebar styling - Icon now always has a background and long names are wrapped correctly

### DIFF
--- a/django_project/core/base_static/css/sidebar.css
+++ b/django_project/core/base_static/css/sidebar.css
@@ -8,7 +8,8 @@
     background-color: var(--c-purple);
     color: #fff;
     transition: all 0.3s;
-    min-height: 100vh;
+    min-height: 100vh
+    padding-bottom: 4rem;
 }
 
 #sidebar.active {
@@ -31,15 +32,17 @@
 }
 
 #sidebar ul li {
-    padding-left: 1rem;
-    padding-top: 0.5rem;
     width: 100%;
     list-style: none;
     cursor: pointer;
     background-color: rgba(255, 255, 255, 0.13);
-    height: 2.5rem;
+    height: 100%;
     line-height: 1.25rem;
     color: var(--c-grey-l);
+    padding-left: 1rem;
+    padding-top: 0.5rem;
+    padding-bottom: 0.5rem;
+    padding-right: 1rem;
 }
 
 #sidebar ul li:hover {
@@ -107,7 +110,8 @@
 .side-bar-kartoza-icon {
     height: 2rem;
     position: fixed;
-    width: 250px;
+    width: 320px;
     background-position: center;
     bottom: 0;
+    background-color: var(--c-purple);
 }

--- a/django_project/core/base_static/css/sidebar.css
+++ b/django_project/core/base_static/css/sidebar.css
@@ -8,7 +8,7 @@
     background-color: var(--c-purple);
     color: #fff;
     transition: all 0.3s;
-    min-height: 100vh
+    min-height: 100vh;
     padding-bottom: 4rem;
 }
 
@@ -39,10 +39,7 @@
     height: 100%;
     line-height: 1.25rem;
     color: var(--c-grey-l);
-    padding-left: 1rem;
-    padding-top: 0.5rem;
-    padding-bottom: 0.5rem;
-    padding-right: 1rem;
+    padding: 0.5rem 1rem;
 }
 
 #sidebar ul li:hover {

--- a/django_project/ford3/templates/base.html
+++ b/django_project/ford3/templates/base.html
@@ -30,7 +30,7 @@
     {# we need this block to disable the block in provider_form.html #}
     {% block side_navbar %}
     <nav id="sidebar" class="col-md-2 px-0">
-        <div class="container-fluid px-0">
+        <div class="container-fluid px-0 pb-3">
             <div class="col-12">
                 <div id="provider-photo" class="provider-photo">
                     {% if provider_logo %}


### PR DESCRIPTION
This closes #401 
![NewGIF](https://user-images.githubusercontent.com/34506346/58787968-3ab10800-85eb-11e9-90c6-1108d684d54e.gif)
