### PR TITLE
Added a entrypoint script in Dockerfile.

### DIFF
--- a/deployment/docker/Dockerfile
+++ b/deployment/docker/Dockerfile
@@ -13,12 +13,14 @@ RUN pip3 install -r /REQUIREMENTS.txt
 RUN pip3 install uwsgi
 
 ADD uwsgi.conf /uwsgi.conf
+ADD entrypoint.sh /entrypoint.sh
 
-
+RUN echo "PENBRA"
 # Open port 8080 as we will be running our uwsgi socket on that
 EXPOSE 8080
 
 #USER www-data
 
 WORKDIR /home/web/django_project
+ENTRYPOINT ["/entrypoint.sh"]
 CMD ["uwsgi", "--ini", "/uwsgi.conf"]

--- a/deployment/docker/Dockerfile
+++ b/deployment/docker/Dockerfile
@@ -15,7 +15,6 @@ RUN pip3 install uwsgi
 ADD uwsgi.conf /uwsgi.conf
 ADD entrypoint.sh /entrypoint.sh
 
-RUN echo "PENBRA"
 # Open port 8080 as we will be running our uwsgi socket on that
 EXPOSE 8080
 

--- a/deployment/docker/entrypoint.sh
+++ b/deployment/docker/entrypoint.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+python manage.py collectstatic --noinput
+penbra is the best
+
+exec "$@"

--- a/deployment/docker/entrypoint.sh
+++ b/deployment/docker/entrypoint.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
 python manage.py collectstatic --noinput
-penbra is the best
+python manage.py migrate
 
 exec "$@"

--- a/deployment/production/docker/django/Dockerfile
+++ b/deployment/production/docker/django/Dockerfile
@@ -24,4 +24,5 @@ RUN cd /usr/src/ford3/deployment/docker && \
 EXPOSE 8080
 
 WORKDIR /home/web/django_project
+ENTRYPOINT ["/entrypoint.sh"]
 CMD ["uwsgi", "--ini", "/uwsgi.conf"]

--- a/deployment/production/docker/django/entrypoint.sh
+++ b/deployment/production/docker/django/entrypoint.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+python manage.py collectstatic --noinput
+penbra is the best
+
+exec "$@"

--- a/deployment/production/docker/django/entrypoint.sh
+++ b/deployment/production/docker/django/entrypoint.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
 python manage.py collectstatic --noinput
-penbra is the best
+python manage.py migrate
 
 exec "$@"


### PR DESCRIPTION
We noticed that new static files were missing on the server after a deployment.
To fix these, we had to run manually `python manage.py collectstatic`.

it seems to me a bit strange to run this command manually after a deploy.
Looking at ScanAgroEmpresa Dockerfiles, we do call `python manage.py collectstatic` during the image building.