### PR TITLE
Removed redundant wording from qualification page: interests and jobs

### DIFF
--- a/django_project/ford3/templates/qualification.html
+++ b/django_project/ford3/templates/qualification.html
@@ -147,19 +147,19 @@
                         {% endfor %}
                     </div>
                 </div>
+
                 <div class="row pb-3">
-                    <div class="col-md-6">
-                        <b>This qualification does prepare the learner for a critical skill.</b>
+	                <div class="col-12"><b>This qualification prepares a learner for a</b></div>
+                    <div class="col-md-12">
+                        - Critical skill
                             {{ qualification.critical_skill|checked_or_crossed}}
                     </div>
-                    <div class="col-md-6">
-                        <b>This qualification does prepare the learner for a green occupation.</b>
+                    <div class="col-md-12">
+                        - Green occupation
                             {{ qualification.green_occupation|checked_or_crossed}}
                     </div>
-                </div>
-                <div class="row pb-3">
-                    <div class="col-md-6">
-                        <b>This qualification does prepare the learner for a high demand occupation.</b>
+	                 <div class="col-md-12">
+                        - High demand occupation
                             {{ qualification.high_demand_occupation|checked_or_crossed }}
                     </div>
                 </div>


### PR DESCRIPTION
This closes #523 

![image](https://user-images.githubusercontent.com/34506346/59362134-3eebcc80-8d33-11e9-84db-f8875b6e0c40.png)
