### PR TITLE
Fix bug campus name too long

### DIFF
--- a/django_project/core/base_static/css/stylesheet.css
+++ b/django_project/core/base_static/css/stylesheet.css
@@ -759,6 +759,11 @@ input[type='email']:hover::placeholder, input[type='url']:hover::placeholder {
 
 nav#sidebar ul li a {
     color: inherit;
+    width: 100%;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    display: block;
 }
 
 nav#sidebar ul li a:hover {
@@ -817,6 +822,14 @@ nav#sidebar ul li a:hover {
 }
 .campus-card .progress-bar {
     background-color: #ffffff;
+}
+
+.campus-card h5 {
+    text-overflow: ellipsis;
+    width: 100%;
+    white-space: nowrap;
+    overflow: hidden;
+    color: white;
 }
 
 .body-wrapper {

--- a/django_project/ford3/static/css/wizard_form.css
+++ b/django_project/ford3/static/css/wizard_form.css
@@ -1,3 +1,10 @@
+.form-campus-title {
+    text-overflow: ellipsis;
+    width: 100%;
+    white-space: nowrap;
+    overflow: hidden;
+}
+
 .nav-wizard-steps {
     margin-top: 1rem;
     margin-bottom: 1rem;

--- a/django_project/ford3/templates/campus.html
+++ b/django_project/ford3/templates/campus.html
@@ -8,7 +8,7 @@
 <div class='row'>
     <div class='col-md-12'>
     {% autoescape off %}
-        <h3>{{ campus }}</h3>
+        <h3>{{ campus|truncatechars:42 }}</h3>
 
         <div class='row'>
             <div class='col'>

--- a/django_project/ford3/templates/campus_form.html
+++ b/django_project/ford3/templates/campus_form.html
@@ -19,7 +19,7 @@
 {% block body %}
 <div class="row">
     <div class="col-md-12">
-        <h3>{{ campus }} - {{ form_name_list|index:wizard.steps.step0 }}</h3>
+        <h3 class='form-campus-title'>{{ campus|truncatechars:42 }} - {{ form_name_list|index:wizard.steps.step0 }}</h3>
     </div>
 	{% if multi_step_form %}
 		<div class='col-md-12'>

--- a/django_project/ford3/views/campus.py
+++ b/django_project/ford3/views/campus.py
@@ -61,8 +61,7 @@ def create(request, provider_id):
         # arg campus_name not present in request.POST
         context['campus_error'] = 'Bad request.'
     except DataError:
-        context['campus_error'] = 'Campus name is too long. (255 characters maximum)'
-
+        context['campus_error'] = 'Campus name is too long. (255 characters maximum)' # noqa
     return render(request, 'provider.html', context)
 
 

--- a/django_project/ford3/views/campus.py
+++ b/django_project/ford3/views/campus.py
@@ -6,6 +6,7 @@ from django.shortcuts import (
     get_object_or_404,
     redirect
 )
+from django.db import DataError
 from django.urls import reverse
 from django.core.exceptions import ValidationError
 from django.utils.datastructures import MultiValueDictKeyError
@@ -59,6 +60,8 @@ def create(request, provider_id):
     except MultiValueDictKeyError:
         # arg campus_name not present in request.POST
         context['campus_error'] = 'Bad request.'
+    except DataError:
+        context['campus_error'] = 'Campus name is too long. (255 characters maximum)'
 
     return render(request, 'provider.html', context)
 


### PR DESCRIPTION
Fix #578 
Added ellipsis to campus name if it is a very long name; 
Avoid creating a campus with a name longer than 255 characters.