### PR TITLE
 Removed sidebar_list_items when provider is present

### DIFF
--- a/django_project/ford3/templates/dashboard/dashboard_sidebar_list_items.html
+++ b/django_project/ford3/templates/dashboard/dashboard_sidebar_list_items.html
@@ -1,4 +1,4 @@
-{#{% if not providers %}#}
+{% if not provider %}
 	<li>
 		<a href="{% url 'dashboard' %}">Providers</a>
 	</li>
@@ -7,4 +7,4 @@
 			<a href="{% url 'dashboard-users' %}">Users</a>
 		</li>
 	{% endif %}
-{#{% endif %}#}
+{% endif %}

--- a/django_project/ford3/templates/ford3/user_list.html
+++ b/django_project/ford3/templates/ford3/user_list.html
@@ -21,7 +21,7 @@
     
     <div class='col-md-12'>
         {% if object_list %}
-        <table class="table">
+        <table class="table table-responsive">
             <thead>
                 <tr>
                     <th scope="col">Email</th>


### PR DESCRIPTION
This closes #583 
Whilst making the gif, I realised the user table wasn't responsive so I fixed it.
![NewGIF](https://user-images.githubusercontent.com/34506346/59712219-15d4ab80-920d-11e9-8c0d-4e17acdd2c09.gif)
